### PR TITLE
Feature/zh text input and avoid overwrite

### DIFF
--- a/src/zh_voice_generator/generate_zh_voice.py
+++ b/src/zh_voice_generator/generate_zh_voice.py
@@ -6,11 +6,9 @@ import os
 import argparse
 
 def generate_zh_voice(input_zn_text, output_sound_file=None):
-    if output_sound_file is None:
-        # Use the current timestamp to generate a unique filename
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_sound_file = f"output_{timestamp}.mp3"
-    
+    # Avoid overwriting existing files by appending timestamp to filename
+    output_sound_file = avoid_overwrite_using_datetime(output_sound_file)
+
     # Generate and save the zn voice file using Google Text-to-Speech (gTTS)
     tts = gTTS(input_zn_text, lang='zh')
     tts.save(output_sound_file)
@@ -30,9 +28,21 @@ def get_args():
     # Parse and return arguments
     return parser.parse_args()
 
+def avoid_overwrite_using_datetime(output_sound_file):
+    if output_sound_file is None:
+        # Use the current timestamp to generate a unique filename if not provided
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H;%M;%S") # Avoid using ':' in filename for Windows compatibility
+        return f"output_{timestamp}.mp3"
+    elif os.path.exists(output_sound_file):
+        # If the filename already exists, append the current timestamp to avoid overwriting
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        return f"{os.path.splitext(output_sound_file)[0]}_{timestamp}.mp3"
+    else:
+        return output_sound_file
+
 if __name__ == "__main__":
     # Get command-line arguments
     args = get_args()
 
     # Generate voice
-    generate_zh_voice(args.output, args.output)
+    generate_zh_voice(args.text, args.output)

--- a/src/zh_voice_generator/generate_zh_voice.py
+++ b/src/zh_voice_generator/generate_zh_voice.py
@@ -2,6 +2,8 @@ from gtts import gTTS
 from pydub import AudioSegment
 from pydub.playback import play
 import datetime
+import os
+import argparse
 
 def generate_zh_voice(input_zn_text, output_sound_file=None):
     if output_sound_file is None:
@@ -19,8 +21,18 @@ def generate_zh_voice(input_zn_text, output_sound_file=None):
 
     print(f"Voice generated and saved to {output_sound_file}")
 
+def get_args():
+    # Setup argument parser
+    parser = argparse.ArgumentParser(description='Generate Chinese voice from text')
+    parser.add_argument('text', type=str, help='Chinese text to convert to voice')
+    parser.add_argument('--output', type=str, help='Output MP3 filename', default=None)
+    
+    # Parse and return arguments
+    return parser.parse_args()
+
 if __name__ == "__main__":
-    # Chinese text for testing
-    sample_text = "你好，这是一个示例。"
-    sample_filename = "sample.mp3"
-    generate_zh_voice(sample_text, sample_filename)
+    # Get command-line arguments
+    args = get_args()
+
+    # Generate voice
+    generate_zh_voice(args.output, args.output)


### PR DESCRIPTION
# JP

## 実施内容
- argsで入力した中文を再生する機能を追加した
- 音声ファイルの上書きを避けるため、既存のものと同じファイル名で保存しようとしたときは、datetimeを加えて上書きを避けるようにした
- ファイル名を指定する`--output`がない場合も、datetimeを追加して上書きを避けるようにした。

## 実施理由
- 多様な中国語の文章を音声にするという基本要件の実装のため
- 生成された音声ファイルの意図しない上書きを防ぐため。

## 次のステップ
- 音声ファイルの保存先の仕様を決め、それに従って実装
  - 現在は暫定的にルートディレクトリに置いているが、もちろん望ましい仕様ではない。
- unit testの実行
  - 以下に示すようなテストを行ったが、PJTの規模がunit testを必要とする段階に達したと感じている。

## 自己レビュー
- 以下の3つのコマンドを試した。
- `python src/zh_voice_generator/generate_zh_voice.py "你 好，欢迎使用这个程序。" --output my_chinese_voice.mp3`
  - `my_chinese_voice.mp3`がルートディレクトリに生成された。
- 2回目の`python src/zh_voice_generator/generate_zh_voice.py "你 好，欢迎使用这个程序。" --output my_chinese_voice.mp3`
  - 既存の`my_chinese_voice.mp3`を避け、`output_2024-08-09_06;33;38.mp3`とdatetimeが名前に付いたファイルを生成した。
- `python src/zh_voice_generator/generate_zh_voice.py "你 好，欢迎使用这个程序。"`
  - 引数に`--output`がないケースでは`output_2024-08-09_06;40;48.mp3`とdatetimeが名前に付いたファイルを生成した

---

## What was done
- Added functionality to play back Chinese text input via command-line arguments.
- Implemented a mechanism to avoid overwriting existing audio files by appending a datetime stamp when attempting to save a file with an existing name.
- Ensured that even when the `--output` option is not provided, a datetime stamp is added to the filename to prevent overwriting.

## Why it was done
- To implement the core requirement of converting diverse Chinese text into speech.
- To prevent unintended overwriting of generated audio files.

## Next steps
- Decide on the specification for the audio file storage location and implement it accordingly.
  - Currently, the files are temporarily stored in the root directory, which is not ideal.
- Execute unit tests.
  - While some tests have been conducted as described below, the project's scale now warrants the introduction of formal unit testing.

## Self-review
- Tested the following three commands:
  - `python src/zh_voice_generator/generate_zh_voice.py "你 好，欢迎使用这个程序。" --output my_chinese_voice.mp3`
    - Generated `my_chinese_voice.mp3` in the root directory.
  - Re-running `python src/zh_voice_generator/generate_zh_voice.py "你 好，欢迎使用这个程序。" --output my_chinese_voice.mp3`
    - Avoided overwriting the existing `my_chinese_voice.mp3` and created a file named `output_2024-08-09_06;33;38.mp3` with a datetime stamp.
  - `python src/zh_voice_generator/generate_zh_voice.py "你 好，欢迎使用这个程序。"`
    - When the `--output` argument was not provided, generated a file named `output_2024-08-09_06;40;48.mp3` with a datetime stamp.

