### PR TITLE
enhancement: Validate and warn against input of non-Chinese or specia…

### DIFF
--- a/src/zh_voice_generator/validators/input_validation.py
+++ b/src/zh_voice_generator/validators/input_validation.py
@@ -1,0 +1,35 @@
+import re
+
+def is_chinese(text):
+    # Check if the text contains Chinese characters
+    zn_unicode_range = r'[\u4e00-\u9fff]'
+    match = re.search(zn_unicode_range, text)
+    if match:
+        print(f"Found Chinese character: {match.group()}")
+    else:
+        print("No Chinese characters found.")
+    return bool(match)
+
+def validate_input(text):
+    # Check if the input is empty
+    if not text.strip():
+        raise ValueError("Input cannot be empty.")
+
+    # Check if the input contains invalid characters (e.g., only emojis or symbols)
+    if not is_chinese(text):
+        raise ValueError("Input must contain Chinese characters.")
+
+    # Add more validation rules as needed...
+
+# Example usage
+try:
+    #input_text = "你好，欢迎使用这个程序。"
+    #input_text = "Hello, welcome to this program."
+    #input_text = "😊👍"
+    #input_text = ""
+    input_text = "歡迎使用這個程序。"
+    print(input_text)
+    validate_input(input_text)
+    print("Input is valid Chinese text.")
+except ValueError as e:
+    print(f"Invalid input: {e}")


### PR DESCRIPTION
# JP

## 実施内容
- 中国語の文字が含まれているテキストに対して「valid」という出力を表示するように変更しました。
- 中国語の文字が含まれていない、または空白や絵文字などの特殊文字のみで構成されたテキストに対して「invalid」という出力を表示するようにしました。

## 実施理由
- 不適切または想定外の文字列に対するエラーハンドリングを強化するため。

## 次のステップ
- 音声ファイルの保存先の仕様決定と実装を行います。
  - [前回のPR](https://github.com/s-sasaki-earthsea-wizard/zh-voice-gTTS-generator/pull/4)から進捗のない課題です。
- 現在 `src/zh_voice_generator/validators/input_validation.py` の Example usage に書かれているエラーハンドリングのテストコードを、ユニットテスト実装時に適切な場所へ移動させます。

## 自己レビュー
- `src/zh_voice_generator/validators/input_validation.py` の Example usage を直接実行しました。
  - "你好，欢迎使用这个程序"に対しての出力は "Input is valid Chinese text." でした。
  - "Hello, welcome to this program." および "😊👍" に対しての出力は "Invalid input: Input must contain Chinese characters." でした。
  - 空の文字列 "" に対しての出力は "Invalid input: Input cannot be empty." でした。
  - 繁体中文 "歡迎使用這個程序。" に対しても "Input is valid Chinese text." という出力を確認しました。


---

# EN

## Summary
- Implemented output indicating that the input text is valid if it contains Chinese characters.
- Added output indicating that the input text is invalid if it does not contain Chinese characters or if it contains only whitespace, emojis, or other special characters.

## Reason for Implementation
- To enhance error handling for inappropriate or unexpected input strings.

## Next Steps
- Determine and implement the specifications for saving the audio files.
  - This task has seen no progress since the [previous PR](https://github.com/s-sasaki-earthsea-wizard/zh-voice-gTTS-generator/pull/4).
- The error handling currently written in the Example usage section of `src/zh_voice_generator/validators/input_validation.py` should be moved to proper unit tests during the implementation of unit tests.

## Self-review
- Directly executed the Example usage in `src/zh_voice_generator/validators/input_validation.py`.
  - The output for "你好，欢迎使用这个程序" was "Input is valid Chinese text."
  - The output for "Hello, welcome to this program." and "😊👍" was "Invalid input: Input must contain Chinese characters."
  - The output for an empty string "" was "Invalid input: Input cannot be empty."
  - The output for Traditional Chinese "歡迎使用這個程序。" was also "Input is valid Chinese text."
