### PR TITLE
feat: Add assigning output file path as args

### DIFF
--- a/src/zh_voice_generator/generate_zh_voice.py
+++ b/src/zh_voice_generator/generate_zh_voice.py
@@ -1,14 +1,15 @@
+import sys
+import os
+import argparse
 from gtts import gTTS
 from pydub import AudioSegment
 from pydub.playback import play
-import datetime
-import os
-import argparse
+
+# Add the project root directory to the system path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from utils.audio_utils import prepare_output_path
 
 def generate_zh_voice(input_zn_text, output_sound_file=None):
-    # Avoid overwriting existing files by appending timestamp to filename
-    output_sound_file = avoid_overwrite_using_datetime(output_sound_file)
-
     # Generate and save the zn voice file using Google Text-to-Speech (gTTS)
     tts = gTTS(input_zn_text, lang='zh')
     tts.save(output_sound_file)
@@ -23,26 +24,18 @@ def get_args():
     # Setup argument parser
     parser = argparse.ArgumentParser(description='Generate Chinese voice from text')
     parser.add_argument('text', type=str, help='Chinese text to convert to voice')
-    parser.add_argument('--output', type=str, help='Output MP3 filename', default=None)
+    parser.add_argument('--output-dir', type=str, help='Output directory', default='output')
+    parser.add_argument('--filename', type=str, help='Output MP3 filename', default=None)
     
     # Parse and return arguments
     return parser.parse_args()
-
-def avoid_overwrite_using_datetime(output_sound_file):
-    if output_sound_file is None:
-        # Use the current timestamp to generate a unique filename if not provided
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H;%M;%S") # Avoid using ':' in filename for Windows compatibility
-        return f"output_{timestamp}.mp3"
-    elif os.path.exists(output_sound_file):
-        # If the filename already exists, append the current timestamp to avoid overwriting
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        return f"{os.path.splitext(output_sound_file)[0]}_{timestamp}.mp3"
-    else:
-        return output_sound_file
 
 if __name__ == "__main__":
     # Get command-line arguments
     args = get_args()
 
+    # Prepare output path
+    output_sound_file = prepare_output_path(args.output_dir, args.filename)
+    
     # Generate voice
-    generate_zh_voice(args.text, args.output)
+    generate_zh_voice(args.text, output_sound_file)

--- a/src/zh_voice_generator/utils/audio_utils.py
+++ b/src/zh_voice_generator/utils/audio_utils.py
@@ -1,0 +1,15 @@
+import os
+import datetime
+
+def prepare_output_path(output_dir='output', filename=None):
+    # Ensure output directory exists
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    
+    # If no filename is provided, generate one
+    if filename is None:
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        filename = f"output_{timestamp}.mp3"
+    
+    return os.path.join(output_dir, filename)
+


### PR DESCRIPTION
# JP

## 実施内容
- コマンドライン引数を使用して、音声ファイルの出力ディレクトリとファイル名を指定できる機能を追加しました。
- デフォルトでは、`output` ディレクトリに日時ベースのファイル名で音声ファイルが保存されるように設定しました。

## 実施理由
- ユーザーが音声ファイルの保存場所と名前を自由に指定できるようにするためです。
  - これは出力される音声ファイルの利用や管理をしやすくするための追加機能です。
- 一方でデフォルトの出力先をあらかじめ用意することで、出力されたファイルの場所がわかりにくくなることを避けています。

## 次のステップ
- [先に追加された validator](https://github.com/s-sasaki-earthsea-wizard/zh-voice-gTTS-generator/pull/7)と併せてunit testを行います。
  - `validator`は中国語以外の言語や絵文字などの特殊文字などの想定しない入力のvalidationを行う機能です。
- READMEなどのドキュメントを更新し、新しい機能の使い方を記載します。

## 自己レビュー
- 以下の4つのコマンドを実行し、すべて期待通りのファイル出力が行われていることを確認しています。
  - `python src/zh_voice_generator/generate_zh_voice.py 你好`
    - ルートディレクトリにdatetimeをもとにしたファイル名で音声ファイルが保存されます。
  - `python src/zh_voice_generator/generate_zh_voice.py 你好 --filename='custom_name.mp3'`
    - ルートディレクトリに`custom_name.mp3`のファイル名で音声ファイルが保存されます。
  - `python src/zh_voice_generator/generate_zh_voice.py 你好 --output-dir='custom_output_dir'`
    - `./custom_output_dir`ディレクトリが作成され、datetimeをもとにしたファイル名で音声ファイルが保存されます。
  - `python src/zh_voice_generator/generate_zh_voice.py 你好 --output-dir='custom_output_dir' --filename='custom_name.mp3'
    - `./custom_output_dir`ディレクトリに`custom_name.mp3`のファイル名で音声ファイルが保存されます。
- メンテナンスしやすい状態にコード全体がリファクタリングされています。

---

# EN

## What was done
- Added the ability to specify the output directory and filename for the generated voice file using command-line arguments.
- Set the default behavior to save the voice file in the `output` directory with a datetime-based filename.

## Why it was done
- To allow users to freely specify the location and name of the voice file, making it easier to use and manage the generated files.
  - This feature was added to improve the usability and management of the generated voice files.
- Additionally, by providing a default output location, we avoid confusion regarding where the generated files are saved.

## Next steps
- Perform unit tests in conjunction with the [previously added validator](https://github.com/s-sasaki-earthsea-wizard/zh-voice-gTTS-generator/pull/7).
  - The `validator` feature handles validation for unexpected inputs, such as non-Chinese characters or special characters like emojis.
- Update the README and other documentation to include instructions on how to use the new features.

## Self-review
- Confirmed that the following four commands all result in the expected file output:
  - `python src/zh_voice_generator/generate_zh_voice.py 你好`
    - The voice file is saved in the root directory with a filename based on the current datetime.
  - `python src/zh_voice_generator/generate_zh_voice.py 你好 --filename='custom_name.mp3'`
    - The voice file is saved in the root directory with the filename `custom_name.mp3`.
  - `python src/zh_voice_generator/generate_zh_voice.py 你好 --output-dir='custom_output_dir'`
    - The `./custom_output_dir` directory is created, and the voice file is saved there with a filename based on the current datetime.
  - `python src/zh_voice_generator/generate_zh_voice.py 你好 --output-dir='custom_output_dir' --filename='custom_name.mp3'`
    - The voice file is saved in the `./custom_output_dir` directory with the filename `custom_name.mp3`.
- The code has been refactored to improve maintainability.
